### PR TITLE
Simplify value parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@std/esm": "^0.19.1",
-    "lodash": "^4.17.4",
     "postcss": "^6.0.1",
     "postcss-value-parser": "^3.3.0"
   },

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -1,6 +1,5 @@
 import postcss from 'postcss'
 import valueParser from 'postcss-value-parser'
-import { flatMap } from 'lodash'
 
 const fontFamilySystemUIList = [
   'system-ui',
@@ -14,24 +13,19 @@ const fontFamilySystemUIList = [
   'Fira Sans',
   'Droid Sans',
   'Helvetica Neue'
-]
+].join(', ');
 
-const parsedFontFamilySystemUIListTree = valueParser(fontFamilySystemUIList.join(', '))
-
-const transformFontFamilySystemUI = (nodes) => {
-  return flatMap(nodes, node => {
-    if (node.type === 'word' && node.value === 'system-ui') {
-      return parsedFontFamilySystemUIListTree
-    }
-    return node
-  })
-}
+const transformFontFamilySystemUI = node => {
+  if (node.type === 'word' && node.value === 'system-ui') {
+    node.value = fontFamilySystemUIList
+  }
+};
 
 const transform = () => (decl) => {
   if (decl.type === 'decl') {
     if (decl.prop === 'font-family' || decl.prop === 'font') {
       const tree = valueParser(decl.value)
-      tree.nodes = transformFontFamilySystemUI(tree.nodes)
+      tree.walk(transformFontFamilySystemUI)
       decl.value = tree.toString()
     }
   }


### PR DESCRIPTION
This PR simplifies the transform of this plugin.

1. It changes the plugin to use postcss-value-parser’s recommended and built-in `walk()` method, which then removes lodash as a dependency.

2. It changes the transform function to update `system-ui` with the stringified font family system-ui list.

All tests pass.