### PR TITLE
fix: ignore browser when version does not exist in caniuse

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -20,6 +20,12 @@ module.exports = {
 				browsers: ["Safari 9", "Safari 10", "IE 11", "Chrome 55", "Chrome 56", "Firefox 57"]
 			}
 		},
+		'basic:browser:edged_version': {
+			message: 'supports browsers usage when caniuse is out-of-dated',
+			options: {
+				browsers: ["Chrome 1048576"]
+			}
+		},
 		'custom-properties': {
 			message: 'supports custom-properties usage'
 		}

--- a/lib/get-system-ui-family.js
+++ b/lib/get-system-ui-family.js
@@ -28,12 +28,12 @@ function generatePolyfillFlags(stats, supportedBrowsers) {
 	for (const browserAndVersion of supportedBrowsers) {
 		const [browser, version] = browserAndVersion.split(' ');
 		const status = stats[browser][version];
-		if (visitedStatus[status]) {
+		if (status === undefined || visitedStatus[status]) {
 			continue;
 		}
 		visitedStatus[status] = true;
 		const shouldPolyfillFlags = computePolyfillFlagFromStatus(status);
-		shouldPolyfillFlags.forEach(flag => polyfillFlags[flag] = true);
+		shouldPolyfillFlags.forEach(flag => { polyfillFlags[flag] = true });
 	}
 	return polyfillFlags;
 }

--- a/test/basic.browser.edged_version.expect.css
+++ b/test/basic.browser.edged_version.expect.css
@@ -1,0 +1,10 @@
+test {
+	font: italic bold 12px/30px system-ui, Helvetica Neue, sans-serif;
+	font: italic bold 12px/30px system-ui, sans-serif;
+	font: italic bold 12px/30px sans-serif;
+	font-family: system-ui, Helvetica Neue, sans-serif;
+	font-family: system-ui, sans-serif;
+	font-family: system-ui;
+	font-family: sans-serif;
+	font-family: "Droid Sans",    system-ui,    sans-serif;
+}


### PR DESCRIPTION
Fixes #197 

When caniuse-lite is not up-to-dated, the supported browserslist will return browser version that does not exist in caniuse-lite. We should ignore such versions, as practically it should be some latest Chrome/Firefox versions that supports `font-family` quite well.