### PR TITLE
feat: add preserve: boolean support

### DIFF
--- a/.tape.cjs
+++ b/.tape.cjs
@@ -26,6 +26,12 @@ module.exports = {
 				browsers: ["Chrome 1048576"]
 			}
 		},
+		'basic:not_preserve': {
+			message: 'supports simple { preserve } usage',
+			options: {
+				preserve: false,
+			}
+		},
 		'custom-properties': {
 			message: 'supports custom-properties usage'
 		}

--- a/index.mjs
+++ b/index.mjs
@@ -8,20 +8,17 @@ export default postcss.plugin('postcss-system-ui-font', opts => {
 
 	return (root, result) => {
 
-		const family = Object(opts).family;
+		const { family, preserve = true, browsers } = Object(opts);
 		let systemUiFamily = family;
 		if (typeof family === 'string') {
 			systemUiFamily = family.trim().split(/\s*,\s*/);
 		} else if (!family) {
-
-			const { browsers } = Object(opts);
-
 			// browsers supported by the configuration
 			const supportedBrowsers = browserslist(browsers, {
 				path: result.root.source && result.root.source.input && result.root.source.input.file,
 				ignoreUnknownVersions: true
 			});
-			systemUiFamily = getSystemUiFamily(supportedBrowsers);
+			systemUiFamily = getSystemUiFamily(supportedBrowsers, preserve);
 		}
 
 		// system-ui and fallbacks match

--- a/lib/get-system-ui-family.mjs
+++ b/lib/get-system-ui-family.mjs
@@ -38,11 +38,11 @@ function generatePolyfillFlags(stats, supportedBrowsers) {
 	return polyfillFlags;
 }
 
-export default function getSystemUiFamily(supportedBrowsers) {
+export default function getSystemUiFamily(supportedBrowsers, preserve) {
 	const { stats } = caniuse.feature(caniuse.features['font-family-system-ui']);
 	const polyfillFlags = generatePolyfillFlags(stats, supportedBrowsers);
 
-	const result = ['system-ui'];
+	const result = preserve ? ['system-ui'] : [];
 	const polyfill =
 		[
 			[APPLE_SYSTEM, [

--- a/test/basic.not_preserve.expect.css
+++ b/test/basic.not_preserve.expect.css
@@ -1,0 +1,10 @@
+test {
+	font: italic bold 12px/30px -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	font: italic bold 12px/30px -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	font: italic bold 12px/30px sans-serif;
+	font-family: -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	font-family: -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	font-family: -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue;
+	font-family: sans-serif;
+	font-family: "Droid Sans",    -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue,    sans-serif;
+}


### PR DESCRIPTION
Add a boolean option `preserve`, which will decide whether `system-ui` will be preserved in the transformed results. The default value is `true`.

Closes #210 