### PR TITLE
chore: update GitHub workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,7 +41,7 @@ jobs:
       - name: npm install
         run: |
           npm install --only=prod
-          npm install --dev postcss-tape@$(node -e 'process.stdout.write(require("./package.json").devDependencies["postcss-tape"])')
+          npm install postcss-tape@$(node -e 'process.stdout.write(require("./package.json").devDependencies["postcss-tape"])')
       - name: download artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,10 +38,14 @@ jobs:
         uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Get npm cache directory
+        id: postcss-tape-version
+        run: |
+          echo "::set-output name=version::$(node -e 'process.stdout.write(require("./package.json").devDependencies["postcss-tape"])')"
       - name: npm install
         run: |
           npm install --only=prod
-          npm install postcss-tape@$(node -e 'process.stdout.write(require("./package.json").devDependencies["postcss-tape"])')
+          npm install postcss-tape@${{ steps.postcss-tape.outputs.version }}
       - name: download artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,14 +38,14 @@ jobs:
         uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get npm cache directory
-        id: postcss-tape-version
+      - name: Get test dep versions
+        id: test-dep-versions
         run: |
-          echo "::set-output name=version::$(node -e 'process.stdout.write(require("./package.json").devDependencies["postcss-tape"])')"
+          echo "::set-output name=postcss-tape::$(node scripts/get-tape-deps postcss-tape)"
       - name: npm install
         run: |
           npm install --only=prod
-          npm install postcss-tape@${{ steps.postcss-tape.outputs.version }}
+          npm install postcss-tape@${{ steps.test-dep-versions.outputs.postcss-tape }}
       - name: download artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js latest
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 14.x
-      - name: npm install and check
+          node-version: "*"
+      - name: Install dependencies
         run: |
           npm install --ignore-scripts
           npm run check
-      - name: build artifact
+      - name: Build artifact
         run: |
           npm run build
-      - name: upload artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: bundled
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get test dep versions
+      - name: Get test dependencies versions
         id: test-dep-versions
         run: |
           echo "::set-output name=postcss-tape::$(node scripts/get-tape-deps postcss-tape)"
@@ -46,10 +46,10 @@ jobs:
         run: |
           npm install --only=prod
           npm install postcss-tape@${{ steps.test-dep-versions.outputs.postcss-tape }}
-      - name: download artifact
+      - name: Download artifact
         uses: actions/download-artifact@v2
         with:
           name: bundled
-      - name: test
+      - name: Test
         run: |
           npm run test:tape

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,9 +6,9 @@ jobs:
   check-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2-beta
         with:
           node-version: 14.x
       - name: npm install and check
@@ -33,15 +33,15 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node-version }}
       - name: npm install
         run: |
           npm install --only=prod
-          npm install --dev postcss-tape@4
+          npm install --dev postcss-tape@$(node -e 'process.stdout.write(require("./package.json").devDependencies["postcss-tape"])')
       - name: download artifact
         uses: actions/download-artifact@v2
         with:

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "echint": "4.0.2",
     "eslint": "7.1.0",
     "eslint-config-dev": "2.0.0",
-    "postcss-tape": "^4.0.0",
+    "postcss-tape": "4.0.0",
     "pre-commit": "1.2.2",
     "rollup": "1.32.1",
     "yaspeller": "7.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "echint": "4.0.2",
     "eslint": "7.1.0",
     "eslint-config-dev": "2.0.0",
-    "postcss-tape": "4.0.0",
+    "postcss-tape": "^4.0.0",
     "pre-commit": "1.2.2",
     "rollup": "1.32.1",
     "yaspeller": "7.0.0"

--- a/scripts/get-tape-deps.js
+++ b/scripts/get-tape-deps.js
@@ -1,0 +1,7 @@
+const fs = require("fs");
+const path = require("path");
+
+process.stdout.write(
+	JSON.parse(fs.readFileSync(path.resolve(__dirname, "../package.json")))
+		.devDependencies[process.argv[2]]
+);

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
Update GitHub workflow versions.

Also sync `postcss-tape` version to the one of package.json so that #155 can not pass, which is expected since `postcss-tape@5` has dropped node.js 8 support.