### PR TITLE
fix: preserve: false should not remove system-ui when it is no-op

### DIFF
--- a/.tape.cjs
+++ b/.tape.cjs
@@ -1,38 +1,52 @@
 module.exports = {
-		'basic': {
-			message: 'supports basic usage'
+	basic: {
+		message: "supports basic usage",
+	},
+	"basic:family": {
+		message: "supports { family } usage",
+		options: {
+			family: "system-ui, Segoe UI, Roboto, Helvetica Neue",
 		},
-		'basic:family': {
-			message: 'supports { family } usage',
-			options: {
-				family: 'system-ui, Segoe UI, Roboto, Helvetica Neue'
-			}
+	},
+	"basic:browser:chrome_60": {
+		message: "supports simple { browsers } usage",
+		options: {
+			browsers: ["Chrome 60"],
 		},
-		'basic:browser:chrome_60': {
-			message: 'supports simple { browsers } usage',
-			options: {
-				browsers: ["Chrome 60"]
-			}
+	},
+	"basic:browser:chrome_60": {
+		message: "preserve: false is no-op when browsers are modern",
+		options: {
+			browsers: ["Chrome 60"],
+			preserve: false,
 		},
-		'basic:browser:whole_coverage': {
-			message: 'supports complex { browsers } usage',
-			options: {
-				browsers: ["Safari 9", "Safari 10", "IE 11", "Chrome 55", "Chrome 56", "Firefox 57"]
-			}
+	},
+	"basic:browser:whole_coverage": {
+		message: "supports complex { browsers } usage",
+		options: {
+			browsers: [
+				"Safari 9",
+				"Safari 10",
+				"IE 11",
+				"Chrome 55",
+				"Chrome 56",
+				"Firefox 57",
+			],
 		},
-		'basic:browser:edged_version': {
-			message: 'supports browsers usage when caniuse is out-of-dated',
-			options: {
-				browsers: ["Chrome 1048576"]
-			}
+	},
+	"basic:browser:edged_version": {
+		message: "supports browsers usage when caniuse is out-of-dated",
+		options: {
+			browsers: ["Chrome 1048576"],
 		},
-		'basic:not_preserve': {
-			message: 'supports simple { preserve } usage',
-			options: {
-				preserve: false,
-			}
+	},
+	"basic:not_preserve": {
+		message: "supports simple { preserve } usage",
+		options: {
+			preserve: false,
 		},
-		'custom-properties': {
-			message: 'supports custom-properties usage'
-		}
+	},
+	"custom-properties": {
+		message: "supports custom-properties usage",
+	},
 };

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ body {
 /* becomes */
 
 body {
-  font: 100%/1.5 system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue;
+  font: 100%/1.5 system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu,
+    Cantarell, Helvetica Neue;
 }
 ```
 
@@ -34,7 +35,7 @@ npm install postcss-font-family-system-ui --save-dev
 Use [postcss-font-family-system-ui] to process your CSS:
 
 ```js
-import postcssSystemUiFont from 'postcss-font-family-system-ui';
+import postcssSystemUiFont from "postcss-font-family-system-ui";
 
 postcssSystemUiFont.process(YOUR_CSS);
 ```
@@ -50,12 +51,10 @@ npm install postcss --save-dev
 Use [postcss-font-family-system-ui] as a plugin:
 
 ```js
-import postcss from 'gulp-postcss';
-import postcssSystemUiFont from 'postcss-font-family-system-ui';
+import postcss from "gulp-postcss";
+import postcssSystemUiFont from "postcss-font-family-system-ui";
 
-postcss([
-  postcssSystemUiFont(/* options */)
-]).process(YOUR_CSS);
+postcss([postcssSystemUiFont(/* options */)]).process(YOUR_CSS);
 ```
 
 #### Gulp
@@ -69,16 +68,15 @@ npm install gulp-postcss --save-dev
 Use [postcss-font-family-system-ui] in your Gulpfile:
 
 ```js
-import postcss from 'gulp-postcss';
-import postcssSystemUiFont from 'postcss-font-family-system-ui';
+import postcss from "gulp-postcss";
+import postcssSystemUiFont from "postcss-font-family-system-ui";
 
-gulp.task('css', () => gulp.src('./src/*.css').pipe(
-  postcss([
-    postcssSystemUiFont(/* options */)
-  ])
-).pipe(
-  gulp.dest('.')
-));
+gulp.task("css", () =>
+  gulp
+    .src("./src/*.css")
+    .pipe(postcss([postcssSystemUiFont(/* options */)]))
+    .pipe(gulp.dest("."))
+);
 ```
 
 #### Grunt
@@ -92,21 +90,19 @@ npm install grunt-postcss --save-dev
 Use [postcss-font-family-system-ui] in your Gruntfile:
 
 ```js
-import postcssSystemUiFont from 'postcss-font-family-system-ui';
+import postcssSystemUiFont from "postcss-font-family-system-ui";
 
-grunt.loadNpmTasks('grunt-postcss');
+grunt.loadNpmTasks("grunt-postcss");
 
 grunt.initConfig({
   postcss: {
     options: {
-      use: [
-       postcssSystemUiFont(/* options */)
-      ]
+      use: [postcssSystemUiFont(/* options */)],
     },
     dist: {
-      src: '*.css'
-    }
-  }
+      src: "*.css",
+    },
+  },
 });
 ```
 
@@ -118,10 +114,10 @@ The `family` option defines the fallback families used to polyfill `system-ui`.
 It accepts an array or a comma-separated string.
 
 ```js
-import postcssSystemUiFont from 'postcss-font-family-system-ui';
+import postcssSystemUiFont from "postcss-font-family-system-ui";
 
 postcssSystemUiFont({
-  family: 'system-ui, Segoe UI, Roboto, Helvetica Neue' // use less fallbacks
+  family: "system-ui, Segoe UI, Roboto, Helvetica Neue", // use less fallbacks
 });
 ```
 
@@ -134,13 +130,34 @@ The `browsers` option determines the supported browsers, which is used to tune l
 [postcss-font-family-system-ui] supports any standard [browserslist] configuration, which includes a `.browserslistrc` file, a `browserslist` key in `package.json`, or `browserslist` environment variables.
 
 The `browsers` option should only be used when a standard browserslist configuration is not available.
+
 ```js
 postcssSystemUiFont({
-  browsers: ["last 2 versions"]
-})
+  browsers: ["last 2 versions"],
+});
 ```
 
 If not valid browserslist configuration is specified, the [default browserslist query](https://github.com/browserslist/browserslist#queries) will be used.
+
+### preserve
+
+The `preserve: boolean` option controls whether `system-ui` should be preserved in the transformed CSS output.
+It accepts only boolean and the default is `true`
+
+```js
+postcssSystemUiFont({
+  preserve: true, // preserve `system-ui` in the transpiled output
+});
+```
+
+Note that if your `browserslist` config targets to browsers which have native support of `system-ui`, this option will be a no-op.
+
+```js
+postcssSystemUiFont({
+  browsers: ["Chrome 60"], // Chrome 60 has native system-ui support
+  preserve: false, // the `system-ui` will still be preserved when it is not polyfilled
+});
+```
 
 [css-img]: https://csstools.github.io/cssdb/badge/system-ui-font-family.svg
 [css-url]: https://csstools.github.io/cssdb/#system-ui-font-family
@@ -148,11 +165,10 @@ If not valid browserslist configuration is specified, the [default browserslist 
 [npm-url]: https://www.npmjs.com/package/postcss-font-family-system-ui
 [git-img]: https://img.shields.io/badge/support-chat-blue.svg
 [git-url]: https://gitter.im/postcss/postcss
-
-[CSS Fonts Module Level 4]: https://drafts.csswg.org/css-fonts-4/#system-ui-def
-[Gulp PostCSS]: https://github.com/postcss/gulp-postcss
-[Grunt PostCSS]: https://github.com/nDmitry/grunt-postcss
+[css fonts module level 4]: https://drafts.csswg.org/css-fonts-4/#system-ui-def
+[gulp postcss]: https://github.com/postcss/gulp-postcss
+[grunt postcss]: https://github.com/nDmitry/grunt-postcss
 [postcss-font-family-system-ui]: https://github.com/JLHwung/postcss-font-family-system-ui
-[PostCSS]: https://github.com/postcss/postcss
+[postcss]: https://github.com/postcss/postcss
 [browserslist]: https://github.com/browserslist/browserslist#readme
 [support matrix]: https://caniuse.com/#feat=font-family-system-ui

--- a/lib/get-system-ui-family.mjs
+++ b/lib/get-system-ui-family.mjs
@@ -48,7 +48,6 @@ function generatePolyfillFlags(stats, supportedBrowsers) {
 export default function getSystemUiFamily(supportedBrowsers, preserve) {
 	const polyfillFlags = generatePolyfillFlags(compatData, supportedBrowsers);
 
-	const result = preserve ? ["system-ui"] : [];
 	const polyfill = [
 		[
 			APPLE_SYSTEM,
@@ -74,8 +73,12 @@ export default function getSystemUiFamily(supportedBrowsers, preserve) {
 			],
 		],
 	];
-	return result.concat.apply(
-		result,
+	const result = [].concat.apply(
+		[],
 		polyfill.filter(([flag]) => polyfillFlags[flag]).map((v) => v[1])
 	);
+	if (!result.length || preserve) {
+		result.unshift("system-ui");
+	}
+	return result;
 }

--- a/test/basic.browser.chrome_60.not_preserve.expect.css
+++ b/test/basic.browser.chrome_60.not_preserve.expect.css
@@ -1,0 +1,10 @@
+test {
+	font: italic bold 12px/30px system-ui, Helvetica Neue, sans-serif;
+	font: italic bold 12px/30px system-ui, sans-serif;
+	font: italic bold 12px/30px sans-serif;
+	font-family: system-ui, Helvetica Neue, sans-serif;
+	font-family: system-ui, sans-serif;
+	font-family: system-ui;
+	font-family: sans-serif;
+	font-family: "Droid Sans", system-ui, sans-serif;
+}


### PR DESCRIPTION
This PR is a follow-up to #252 .

It fixes a bug introduced before and adds docs about the `preserve: boolean` option.