### PR TITLE
fix: the script get-dev-deps in get-dev-deps.js

### DIFF
--- a/scripts/get-dev-deps.js
+++ b/scripts/get-dev-deps.js
@@ -1,7 +1,8 @@
 const fs = require("fs");
 const path = require("path");
 
-process.stdout.write(
-	JSON.parse(fs.readFileSync(path.resolve(__dirname, "../package.json")))
-		.devDependencies[process.argv[2]]
-);
+const key = process.argv[2];
+const devDependencies = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../package.json"))).devDependencies;
+if (Object.prototype.hasOwnProperty.call(devDependencies, key)) {
+	process.stdout.write(devDependencies[key]);
+}


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/get-dev-deps.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/get-dev-deps.js:4` |
| **Assessment** | Likely exploitable |

**Description**: The script get-dev-deps.js reads a property name from process.argv[2] and uses it to access a property of the devDependencies object without validation. This allows an attacker to access arbitrary properties, including prototype properties like '__proto__' or 'constructor', potentially leading to information disclosure or unexpected behavior.

## Evidence

**Exploitation scenario**: An attacker with the ability to invoke this script (e.g., through a build system, CI/CD pipeline, or another vulnerable interface) can supply arbitrary property names as the second command-line.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `scripts/get-dev-deps.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
